### PR TITLE
Fix Add Transaction not working on Super Admin transactions page

### DIFF
--- a/src/components/SuperAdmin/transactions/Transaction.jsx
+++ b/src/components/SuperAdmin/transactions/Transaction.jsx
@@ -11,6 +11,7 @@ import {
 import { TransactionModal } from 'src/components/organisms/Modal/TransactionModal';
 import PropTypes from 'prop-types';
 import { useDeleteData } from 'src/react-query/useFetchApis';
+import { fetchData } from 'src/react-query/useApis';
 import ConfirmationDialog from 'src/components/organisms/Modal/ConfirmationDialog';
 import ReactSelectDropdown from 'src/components/atoms/Search/ReactSelectDropdown';
 import { FormControl, InputLabel, MenuItem, Paper, Select } from '@mui/material';
@@ -40,17 +41,11 @@ export const Transaction = () => {
   const [showFilters, setShowFilters] = useState(false);
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
   const [isFiltered, setIsFiltered] = useState(false);
-  const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
-  const fetchTransactions = async () => {
-    const response = await fetch(`${API_BASE_URL}/transactions/`);
-    if (!response.ok) {
-      throw new Error('Network response was not ok');
-    }
-    return response.json();
-  };
-
-  const { data, isLoading } = useQuery('transactions', fetchTransactions, {
+  // Goes through the connector's fetchData (Firebase or Django, whichever is
+  // active) instead of hitting REACT_APP_API_BASE_URL directly, matching how
+  // every other admin CRUD page in the app reads/writes data.
+  const { data, isLoading } = useQuery('transactions', () => fetchData('/transactions/'), {
     staleTime: 30000, // Cache for 30 seconds
     refetchOnWindowFocus: false,
   });

--- a/src/components/organisms/Modal/TransactionModal.jsx
+++ b/src/components/organisms/Modal/TransactionModal.jsx
@@ -3,6 +3,7 @@ import { auth } from 'src/services/Authentication/firebase';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import PropTypes from 'prop-types';
 import { useUpdateData } from 'src/react-query/useFetchApis';
+import { fetchData, addData } from 'src/react-query/useApis';
 import { capitalizeName } from '../Utils';
 import { Autocomplete, TextField } from '@mui/material';
 import { Modal, Button } from 'react-bootstrap';
@@ -16,7 +17,6 @@ export const TransactionModal = ({
   setShowModal,
 }) => {
   const queryClient = useQueryClient();
-  const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
   const [formData, setFormData] = useState({
     receiver_name: '',
     sender_name: '',
@@ -32,12 +32,11 @@ export const TransactionModal = ({
   const [fieldErrors, setFieldErrors] = useState({});
   const [disableButton, setDisableButton] = useState(true);
 
-  // Fetch all transactions to get existing names
-  const { data: transactions = [] } = useQuery('transactions', async () => {
-    const response = await fetch(`${API_BASE_URL}/transactions/`);
-    if (!response.ok) throw new Error('Network response was not ok');
-    return response.json();
-  });
+  // Fetch all transactions to get existing names. Goes through the connector's
+  // fetchData (Firebase or Django, whichever is active) instead of hitting
+  // REACT_APP_API_BASE_URL directly, and shares the 'transactions' query key
+  // with the Transaction list page so both stay in sync.
+  const { data: transactions = [] } = useQuery('transactions', () => fetchData('/transactions/'));
 
   // Fetch subsidiaries from backend
   const { data: subsidiariesData, isLoading: isSubsidiariesLoading } = useGetSubsidiaries();
@@ -134,14 +133,7 @@ export const TransactionModal = ({
   };
 
   const { mutate: createTransaction, isLoading } = useMutation(
-    formData =>
-      fetch(`${API_BASE_URL}/transactions/create/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      }).then(res => res.json()),
+    formData => addData('/transactions/create/', formData),
     {
       onSuccess: () => {
         queryClient.invalidateQueries('transactions');
@@ -212,7 +204,6 @@ export const TransactionModal = ({
     }
 
     createTransaction(upload_data);
-    toggleModal();
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `Transaction.jsx` and `TransactionModal.jsx` fetched/created transactions via raw `fetch()` calls against `REACT_APP_API_BASE_URL` (the legacy Django backend), bypassing the data connector that every other admin CRUD page uses and that this same page's edit/delete already relied on.
- Since Firebase is the app's default active provider and no Django backend is deployed, the raw create request silently failed — this is why "Add Transaction" appeared broken.
- Both files now go through `fetchData`/`addData` from `src/react-query/useApis`, so listing and creating transactions read/write Firestore like the rest of the app.
- Removed a bug where the Add Transaction modal closed immediately after firing the create request regardless of success, which hid failures from the user; it now only closes on the mutation's `onSuccess`.

## Test plan
- [x] `npm run build` completes with no new errors (only pre-existing, unrelated lint warnings)
- [ ] Manually verify in the deployed app: Super Admin → Transactions → Add Transaction creates a row and appears in the table


---
_Generated by [Claude Code](https://claude.ai/code/session_018zDZPUc5crszvcmnqc6GaZ)_