### PR TITLE
Deploy Firestore rules from CI on merge to main

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -1,0 +1,69 @@
+# Deploys Firestore security rules to the `anddhen` Firebase project.
+#
+# Rules are the one part of this repo that Vercel does NOT ship — Vercel builds
+# and hosts the frontend only. Before this workflow, a rules change merged to
+# main sat un-deployed until someone remembered to run the CLI by hand, which
+# silently breaks any feature whose writes the new rules are meant to allow.
+#
+# Requires a repository secret named FIREBASE_SERVICE_ACCOUNT containing the
+# full JSON key of a service account in the `anddhen` project. See
+# firestore/README.md for how to generate it and which IAM roles it needs.
+name: Deploy Firestore rules
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'firestore.rules'
+      - '.github/workflows/deploy-firestore-rules.yml'
+  # Lets you re-run a deploy without pushing a commit (Actions tab > Run workflow).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never let two rules deploys race each other; the last one merged should win.
+concurrency:
+  group: deploy-firestore-rules
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Fail with a readable message rather than an opaque CLI auth error.
+      - name: Check the service account secret is present
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT is not set. Add the service account JSON under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
+
+      # Only `firestore:rules` — deploying indexes can drop indexes missing from
+      # firestore.indexes.json, so that stays a deliberate manual step. Add
+      # `,storage` here if you want storage.rules shipped the same way.
+      - name: Deploy Firestore rules
+        run: |
+          npx --yes firebase-tools@15 deploy \
+            --only firestore:rules \
+            --project anddhen \
+            --non-interactive
+
+      - name: Remove credentials from the runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -15,6 +15,46 @@ firebase use anddhen          # select the project
 firebase deploy --only firestore:rules,firestore:indexes,storage
 ```
 
+## Automatic rules deploy (CI)
+
+`firestore.rules` deploys itself. Any change to that file merged to `main` triggers
+`.github/workflows/deploy-firestore-rules.yml`, which runs
+`firebase deploy --only firestore:rules --project anddhen`. You can also re-run it by
+hand from the repo's **Actions** tab → *Deploy Firestore rules* → **Run workflow**.
+
+Vercel builds and hosts the frontend only — it never ships rules. Without this
+workflow a rules change stays un-deployed after merge, and any feature relying on the
+new rules fails with `PERMISSION_DENIED` while the UI looks fine.
+
+Indexes and storage rules are deliberately **not** automated: deploying
+`firestore:indexes` can drop indexes that aren't in `firestore.indexes.json`. Ship
+those with the manual command above.
+
+### One-time: the CI service account
+
+1. [Firebase Console](https://console.firebase.google.com/project/anddhen/settings/serviceaccounts/adminsdk)
+   → ⚙️ **Project settings** → **Service accounts** → **Generate new private key** →
+   **Generate key**. A `.json` file downloads. Treat it as a password — it grants
+   write access to the project.
+2. Grant it the roles it needs, in the
+   [Google Cloud IAM console](https://console.cloud.google.com/iam-admin/iam?project=anddhen)
+   (find the `firebase-adminsdk-…@anddhen.iam.gserviceaccount.com` principal → ✏️ edit):
+   - **Firebase Rules Admin** (`roles/firebaserules.admin`) — required, publishes rules
+   - **Service Usage Consumer** (`roles/serviceusage.serviceUsageConsumer`) — required by
+     the CLI's API calls
+   - **Cloud Datastore Index Admin** — only if you later add `firestore:indexes` to the
+     workflow
+3. GitHub → repo **Settings** → **Secrets and variables** → **Actions** →
+   **New repository secret**:
+   - Name: `FIREBASE_SERVICE_ACCOUNT`
+   - Value: the **entire contents** of the downloaded JSON file, pasted as-is
+     (open it in a text editor, select all, paste — including the outer `{ }`)
+4. Delete the downloaded file from your machine. GitHub can't show a secret again
+   after saving; to rotate, generate a new key and update the secret.
+
+Never commit the JSON, and don't put it in a Claude Code cloud-environment variable —
+those are plain text readable by anyone using the environment.
+
 ## Seed reference data
 1. Console → Project settings → Service accounts → **Generate new private key**.
 2. Save as `firestore/serviceAccount.json` (gitignored).


### PR DESCRIPTION
## Problem

Vercel builds and hosts the frontend only — it never ships `firestore.rules`. So a rules change merged to `main` sits un-deployed until someone remembers to run the CLI by hand, and any feature whose writes the new rules are meant to allow fails with `PERMISSION_DENIED` while the UI looks completely fine. The card-access work in #240 hit exactly this.

The repo had no `.github/workflows` directory at all.

## Changes

- **`.github/workflows/deploy-firestore-rules.yml`** — runs `firebase deploy --only firestore:rules --project anddhen` whenever `firestore.rules` changes on `main`. Also re-runnable by hand via **Actions → Deploy Firestore rules → Run workflow**.
  - Authenticates with a `FIREBASE_SERVICE_ACCOUNT` repo secret written to a temp file and exposed as `GOOGLE_APPLICATION_CREDENTIALS`, then removed in an `always()` step.
  - Fails early with a readable message if the secret is missing, instead of an opaque CLI auth error.
  - `concurrency` group so two rules deploys can't race; last merge wins.
- **`firestore/README.md`** — documents generating the service-account key, the IAM roles it needs, and adding it as a repo secret.

Scoped to `firestore:rules` only: deploying `firestore:indexes` can drop indexes absent from `firestore.indexes.json`, so that stays a deliberate manual step. Storage rules can be added to the same `--only` flag later; there's a comment marking the spot.

## Required before this works

A repo secret `FIREBASE_SERVICE_ACCOUNT` containing the full JSON key of a service account in the `anddhen` project, with **Firebase Rules Admin** and **Service Usage Consumer**. Full walkthrough in `firestore/README.md`. Until the secret exists the workflow fails fast with a message naming it.

## Testing

- Workflow YAML parses; triggers (`push`, `workflow_dispatch`) and all 6 steps resolve as intended.
- The rules this will deploy were verified against the Firestore emulator in #240 — 9/9 assertions passed, covering self-grant denial, admin grants, and the re-login merge write.
- End-to-end deploy is unverifiable until the secret is added, since the credential is the thing being wired up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_