### PR TITLE
Deploy Cloud Functions from CI on merge to main

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,74 @@
+# Deploys the Cloud Functions in functions/ to the `anddhen` Firebase project.
+#
+# Like firestore.rules, functions are not shipped by Vercel — Vercel builds and
+# hosts the frontend only. Without this, a change to functions/ merged to main
+# stays un-deployed and the callable endpoints keep running old code.
+#
+# Requires more than the rules deploy does. See functions/README.md:
+#   - Blaze (pay-as-you-go) billing on the project — v2 functions won't deploy on Spark
+#   - The FIREBASE_SERVICE_ACCOUNT principal needs the deploy roles listed there
+#   - The OPENAI_API_KEY secret must exist in Secret Manager (aiSuggestions binds it)
+name: Deploy Cloud Functions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'functions/**'
+      - '.github/workflows/deploy-functions.yml'
+  # Lets you deploy without pushing a commit (Actions tab > Run workflow).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Function deploys are slow and mutate live infrastructure; never overlap them.
+concurrency:
+  group: deploy-functions
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Match functions/package.json `engines.node` so CI installs resolve the
+      # same tree the runtime will execute.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install function dependencies
+        working-directory: functions
+        run: npm ci
+
+      # Fail with a readable message rather than an opaque CLI auth error.
+      - name: Check the service account secret is present
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT is not set. Add the service account JSON under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
+
+      - name: Deploy functions
+        run: |
+          npx --yes firebase-tools@15 deploy \
+            --only functions \
+            --project anddhen \
+            --non-interactive
+
+      - name: Remove credentials from the runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -40,10 +40,15 @@ those with the manual command above.
    [Google Cloud IAM console](https://console.cloud.google.com/iam-admin/iam?project=anddhen)
    (find the `firebase-adminsdk-…@anddhen.iam.gserviceaccount.com` principal → ✏️ edit):
    - **Firebase Rules Admin** (`roles/firebaserules.admin`) — required, publishes rules
-   - **Service Usage Consumer** (`roles/serviceusage.serviceUsageConsumer`) — required by
-     the CLI's API calls
+   - **Service Usage Consumer** (`roles/serviceusage.serviceUsageConsumer`) — required.
+     Every deploy first checks that `firestore.googleapis.com` is enabled; without this
+     role the run dies on `HTTP Error: 403, Caller does not have required permission to
+     use project anddhen` before it ever reaches the rules
    - **Cloud Datastore Index Admin** — only if you later add `firestore:indexes` to the
      workflow
+
+   Granting the key alone is not enough — a valid credential with no roles still gets a
+   403. Deploying functions needs a wider set again; see `functions/README.md`.
 3. GitHub → repo **Settings** → **Secrets and variables** → **Actions** →
    **New repository secret**:
    - Name: `FIREBASE_SERVICE_ACCOUNT`

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,57 @@
+# Cloud Functions
+
+Callable (v2) compute endpoints for the `anddhen` project — see the header comment in
+`index.js` for the contract of each one.
+
+## Deploy
+
+`functions/**` changes merged to `main` deploy automatically via
+`.github/workflows/deploy-functions.yml`. You can also re-run it by hand from the
+repo's **Actions** tab → *Deploy Cloud Functions* → **Run workflow**.
+
+Manual deploy from a machine with `firebase login`:
+
+```bash
+cd functions && npm i && npm run deploy
+```
+
+## Prerequisites for the CI deploy
+
+Function deploys need materially more than the rules deploy does. All three must hold
+or the workflow fails:
+
+### 1. Blaze billing
+
+v2 functions build a container and run on Cloud Run, so the project must be on the
+**Blaze** (pay-as-you-go) plan. On Spark the deploy is rejected outright.
+
+### 2. IAM roles on the `FIREBASE_SERVICE_ACCOUNT` principal
+
+Grant these in the
+[IAM console](https://console.cloud.google.com/iam-admin/iam?project=anddhen), on top
+of the roles the rules deploy needs:
+
+| Role | Why |
+| --- | --- |
+| `roles/serviceusage.serviceUsageConsumer` | Every deploy checks that required APIs are enabled. Without it you get `HTTP Error: 403, Caller does not have required permission to use project anddhen` before anything else runs |
+| `roles/cloudfunctions.admin` | Create and update the functions |
+| `roles/run.admin` | v2 functions are Cloud Run services underneath |
+| `roles/iam.serviceAccountUser` | Lets the deployer act as the functions' runtime service account |
+| `roles/artifactregistry.admin` | Stores the built container images |
+| `roles/cloudbuild.builds.editor` | Runs the build |
+| `roles/secretmanager.secretAccessor` | `aiSuggestions` binds the `OPENAI_API_KEY` secret |
+
+`roles/editor` covers all of these in one grant, but hands the CI key far more power
+than deploying needs — prefer the granular list.
+
+### 3. The `OPENAI_API_KEY` secret must exist
+
+`aiSuggestions` declares `defineSecret('OPENAI_API_KEY')`, and the deploy fails if the
+secret isn't in Secret Manager. Create it once from a machine with `firebase login`:
+
+```bash
+firebase functions:secrets:set OPENAI_API_KEY --project anddhen
+```
+
+The stocks functions (`searchSymbols`, `stockMetrics`) need no API key — they use
+Yahoo Finance via `yahoo-finance2`.


### PR DESCRIPTION
## Problem

Same gap `firestore.rules` had before #241: Vercel builds and hosts the frontend only, so a change under `functions/` merged to `main` stays un-deployed and the callable endpoints keep running old code.

## Changes

- **`.github/workflows/deploy-functions.yml`** — mirrors the rules workflow. `npm ci` against `functions/package-lock.json` on Node 20 (matching `engines.node`, so CI resolves the same tree the runtime executes), then `firebase deploy --only functions --project anddhen`, authenticated by the same `FIREBASE_SERVICE_ACCOUNT` secret. Triggers on `functions/**` changes to `main`, plus `workflow_dispatch`. Credentials are removed in an `always()` step, and a `concurrency` group prevents overlapping deploys of live infrastructure.
- **`functions/README.md`** (new) — documents the three prerequisites, since functions need materially more than rules:
  1. **Blaze billing** — v2 functions build a container and run on Cloud Run; Spark rejects the deploy
  2. **Seven IAM roles** on the deploy principal (`cloudfunctions.admin`, `run.admin`, `iam.serviceAccountUser`, `artifactregistry.admin`, `cloudbuild.builds.editor`, `secretmanager.secretAccessor`, `serviceusage.serviceUsageConsumer`)
  3. **`OPENAI_API_KEY` in Secret Manager** — `aiSuggestions` declares `defineSecret('OPENAI_API_KEY')` and the deploy fails without it
- **`firestore/README.md`** — expanded on `serviceUsageConsumer` after the first live run failed on it.

## Status of the rules deploy

Run [#31453213032](https://github.com/AbhiGattineni/Anddhen-Group/actions/runs/31453213032) confirmed the secret is wired correctly — the secret-present check and credential write both passed, and the CLI authenticated against Google. It then failed with:

```
Error: HTTP Error: 403, Caller does not have required permission to use project anddhen.
Grant the caller the roles/serviceusage.serviceUsageConsumer role
```

A valid key with no IAM roles still gets a 403. Granting that role and re-running is all the rules deploy needs.

## Testing

- Workflow YAML parses; triggers and all 7 steps resolve as intended.
- End-to-end deploy is **not** verified — it can't be until the IAM roles, Blaze plan, and `OPENAI_API_KEY` secret are in place. Expect the first run to fail on whichever of those is missing; each failure names the specific role or resource.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_