### PR TITLE
Log the deploying identity so a 403 is self-diagnosing

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -54,6 +54,23 @@ jobs:
           printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
 
+      # A 403 here is ambiguous: it can mean the roles are missing, OR that the
+      # key belongs to a different project than the one being deployed to, in
+      # which case granting roles on `anddhen` changes nothing. These two fields
+      # are identifiers, not credentials — printing them makes that distinction
+      # obvious instead of guesswork. project_id MUST read `anddhen`.
+      - name: Show which identity is deploying
+        run: |
+          node -e '
+            const sa = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+            console.log("project_id  :", sa.project_id);
+            console.log("client_email:", sa.client_email);
+            if (sa.project_id !== "anddhen") {
+              console.log("::error::This key belongs to project \"" + sa.project_id + "\", not \"anddhen\". Regenerate the key from the anddhen project and update the FIREBASE_SERVICE_ACCOUNT secret.");
+              process.exit(1);
+            }
+          '
+
       # Only `firestore:rules` — deploying indexes can drop indexes missing from
       # firestore.indexes.json, so that stays a deliberate manual step. Add
       # `,storage` here if you want storage.rules shipped the same way.

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -62,6 +62,20 @@ jobs:
           printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
 
+      # See the same step in deploy-firestore-rules.yml — a 403 can mean missing
+      # roles OR a key from the wrong project; these identifiers tell them apart.
+      - name: Show which identity is deploying
+        run: |
+          node -e '
+            const sa = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+            console.log("project_id  :", sa.project_id);
+            console.log("client_email:", sa.client_email);
+            if (sa.project_id !== "anddhen") {
+              console.log("::error::This key belongs to project \"" + sa.project_id + "\", not \"anddhen\". Regenerate the key from the anddhen project and update the FIREBASE_SERVICE_ACCOUNT secret.");
+              process.exit(1);
+            }
+          '
+
       - name: Deploy functions
         run: |
           npx --yes firebase-tools@15 deploy \


### PR DESCRIPTION
## Problem

Three rules-deploy runs have now failed with a byte-identical 403:

```
HTTP Error: 403, Caller does not have required permission to use project anddhen.
Grant the caller the roles/serviceusage.serviceUsageConsumer role
```

The third failed *after* `Service Usage Consumer` was granted to `firebase-adminsdk-…@anddhen.iam.gserviceaccount.com`. That error can't distinguish between two very different causes:

1. The roles genuinely aren't there yet (or haven't propagated), or
2. The key in `FIREBASE_SERVICE_ACCOUNT` belongs to a **different project** — in which case granting roles on `anddhen` changes nothing, because the caller is some other project's service account. Worth ruling out: an earlier screenshot of the IAM page was for the `indimitra` project, which already had a full CI role set.

## Changes

Both workflows now print `project_id` and `client_email` from the key before deploying, and fail fast with a pointed message when `project_id` isn't `anddhen`.

Both fields are identifiers, not credentials — the private key is what's sensitive, and that is never logged. This turns an ambiguous 403 into a definite answer on the very next run.

## Testing

- Both workflow YAMLs parse; step counts are 7 (rules) and 8 (functions).
- Merging this touches `.github/workflows/deploy-firestore-rules.yml`, which is in that workflow's own `paths` filter, so the rules deploy re-runs automatically and reports the identity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_