### PR TITLE
Surface the UID behind a role, so a stale User doc is visible

### DIFF
--- a/src/components/SuperAdmin/RoleAccess/RoleManager.jsx
+++ b/src/components/SuperAdmin/RoleAccess/RoleManager.jsx
@@ -117,6 +117,7 @@ const RoleManager = () => {
               <tr>
                 <th>Name</th>
                 <th>Email</th>
+                <th>Doc ID (UID)</th>
                 <th>Current role</th>
                 <th style={{ minWidth: 180 }}>Change role</th>
               </tr>
@@ -124,7 +125,7 @@ const RoleManager = () => {
             <tbody>
               {filtered.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="text-center text-muted py-4">
+                  <td colSpan={5} className="text-center text-muted py-4">
                     No users found.
                   </td>
                 </tr>
@@ -133,10 +134,25 @@ const RoleManager = () => {
                 const current = u.role || ROLES.USER;
                 const options = assignableOptions(myRole, current);
                 const locked = !canAssign(myRole, current, ROLES.EMPLOYEE) && options.length <= 1;
+                // The app resolves a role by reading User/{firebase-uid}, so a doc
+                // whose id doesn't match its own user_id is a stale/duplicate row:
+                // editing it changes nothing the signed-in user will ever see.
+                const orphaned = !!u.user_id && u.user_id !== u.id;
                 return (
                   <tr key={u.id}>
                     <td>{u.full_name || '—'}</td>
                     <td>{u.email_id || u.id}</td>
+                    <td>
+                      <code className="small">{u.id}</code>
+                      {orphaned && (
+                        <span
+                          className="badge bg-warning text-dark ms-2"
+                          title={`This document's id does not match its user_id field (${u.user_id}). The app reads User/<uid>, so a role set here has no effect. Edit the row whose Doc ID equals the user's UID instead.`}
+                        >
+                          stale doc
+                        </span>
+                      )}
+                    </td>
                     <td>
                       <span className={`badge ${badgeClass(current)}`}>
                         {ROLE_LABELS[current] || current}

--- a/src/components/pages/NotAuthorizedPage.jsx
+++ b/src/components/pages/NotAuthorizedPage.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useRole } from 'src/services/roles/RoleContext';
 import { ROLE_LABELS, ROLES } from 'src/services/roles/roles';
 import { cardLabel, normalizeCards } from 'src/services/roles/cards';
+import { auth } from 'src/services/Authentication/firebase';
 
 /**
  * 403 page. ProtectedRoute passes a `reason` in navigation state, so instead of
@@ -69,7 +70,15 @@ const NotAuthorizedPage = () => {
         <p className="fs-5 mb-2">{detail.headline}</p>
         <p className="text-muted">{detail.body}</p>
         {detail.fix && <p className="text-muted small">{detail.fix}</p>}
-        {state?.from && <p className="text-muted small mb-4">Requested page: {state.from}</p>}
+        {state?.from && <p className="text-muted small mb-1">Requested page: {state.from}</p>}
+        {/* The app resolves roles from User/<uid>, so showing the uid lets an
+            admin confirm they edited that exact document and not a stale
+            duplicate that happens to carry the same name or email. */}
+        {auth.currentUser && (
+          <p className="text-muted small mb-4">
+            Signed in as {auth.currentUser.email} · UID <code>{auth.currentUser.uid}</code>
+          </p>
+        )}
         <div className="d-flex gap-2 justify-content-center">
           <Link to="/" className="btn btn-primary">
             Go Home


### PR DESCRIPTION
## Problem

An account (`anddhenconsulting`) was set to **Employee** in the UI but still resolved as **User** at runtime, hitting the 403 on `/employeedashboard`.

The app resolves a role by reading `User/{firebase-uid}.role`. `RoleManager` lists *every* document in the `User` collection, including legacy rows whose document id is not the signed-in uid. Setting a role on one of those writes to a document nothing reads — and neither screen gave any way to notice, since the name and email look identical.

## Changes

Diagnostics only — no change to how roles are read or written.

- **RoleManager** shows each row's document id, and flags rows whose id doesn't match their own `user_id` field with a **"stale doc"** badge. The tooltip spells out that a role set there has no effect and which row to edit instead.
- **403 page** shows the signed-in email and uid, so an admin can match the person reporting the problem to the exact document that governs their access.

## How to use it

1. The blocked user opens the 403 and reads off their **UID**.
2. In Roles & Access → User Roles, find the row whose **Doc ID** equals that UID and set *that* row to Employee.
3. Any row for the same person carrying a "stale doc" badge is a leftover and can be ignored or deleted.

## Testing

- `react-app-rewired build` — compiles, build folder ready.
- `eslint` — clean on both touched files.
- The duplicate-document theory is inferred from the symptom (UI says Employee, runtime says User) and from `RoleManager` keying by document id while `ensureUserProfile` reads by uid. I can't query the project's Firestore from this environment to confirm the duplicate exists — these changes are what make it visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_