### PR TITLE
Send users home on logout instead of to the login page

### DIFF
--- a/src/components/organisms/Navbar.js
+++ b/src/components/organisms/Navbar.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { logout } from '../../services/Authentication/Logout';
 import useAuthStore from '../../services/store/globalStore';
 import { useAuth } from 'src/hooks/useAuth';
@@ -17,15 +17,20 @@ function Navbar() {
   const dashboardTo = hasAtLeast(role, ROLES.EMPLOYEE) ? '/employeedashboard' : null;
 
   const setNewUser = useAuthStore(state => state.setParttimer_consent);
-  const handleLogout = () => {
-    logout()
-      .then(() => {
-        setNewUser(false);
-      })
-      .catch(error => {
-        console.error(error);
-      });
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
     setNavbarOpen(false);
+    // Leave the protected page BEFORE auth clears. Signing out first would let
+    // ProtectedRoute see a signed-out user still sitting on a guarded route and
+    // send them to /login (recording it as preLoginPath) instead of home.
+    navigate('/', { replace: true });
+    try {
+      await logout();
+      setNewUser(false);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const handleLinkClick = () => {


### PR DESCRIPTION
## Problem

`handleLogout` signed out but never navigated, so the user stayed on whatever page they were on. On a protected route that meant `ProtectedRoute` observed a signed-out user on a guarded path, recorded it as `preLoginPath`, and redirected to `/login` — logging out looked like being asked to log straight back in.

## Change

Navigate to `/` **before** signing out, so the guard never observes a signed-out user on a protected route. The sign-out then completes on a public page.

`logout()` already clears `localStorage`, so the `preLoginPath` written by any earlier redirect goes with it.

## Testing

- `react-app-rewired build` — compiles, build folder ready.
- `eslint` — no errors on the touched file (one pre-existing warning unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_