### PR TITLE
Keep roles live, and stop reporting a failed lookup as role &quot;User&quot;

### DIFF
--- a/src/components/SuperAdmin/RoleAccess/RoleManager.jsx
+++ b/src/components/SuperAdmin/RoleAccess/RoleManager.jsx
@@ -90,6 +90,18 @@ const RoleManager = () => {
       (u.full_name || '').toLowerCase().includes(q)
   );
 
+  // Same email on more than one document means only one of them is the doc the
+  // app actually reads (User/{firebase-uid}); a role set on the other is
+  // invisible at runtime. Catching it by email also flags legacy rows that
+  // carry no user_id field at all, which the per-row id check can't see.
+  const emailCounts = users.reduce((acc, u) => {
+    const key = (u.email_id || '').toLowerCase();
+    if (key) acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+  const isDuplicated = u => (emailCounts[(u.email_id || '').toLowerCase()] || 0) > 1;
+  const duplicateCount = Object.values(emailCounts).filter(n => n > 1).length;
+
   const badgeClass = role => ROLE_BADGE[role] || 'bg-secondary';
 
   return (
@@ -107,6 +119,15 @@ const RoleManager = () => {
       </div>
 
       {error && <div className="alert alert-danger py-2">{error}</div>}
+
+      {duplicateCount > 0 && (
+        <div className="alert alert-warning py-2">
+          {duplicateCount} email{duplicateCount === 1 ? ' is' : 's are'} on more than one document.
+          Access is decided by the document whose <strong>Doc ID</strong> equals the user&apos;s
+          Firebase UID — a role set on any other copy is ignored. The user can read their UID off
+          the 403 page.
+        </div>
+      )}
 
       {loading ? (
         <div className="text-muted">Loading users…</div>
@@ -144,12 +165,16 @@ const RoleManager = () => {
                     <td>{u.email_id || u.id}</td>
                     <td>
                       <code className="small">{u.id}</code>
-                      {orphaned && (
+                      {(orphaned || isDuplicated(u)) && (
                         <span
                           className="badge bg-warning text-dark ms-2"
-                          title={`This document's id does not match its user_id field (${u.user_id}). The app reads User/<uid>, so a role set here has no effect. Edit the row whose Doc ID equals the user's UID instead.`}
+                          title={
+                            orphaned
+                              ? `This document's id does not match its user_id field (${u.user_id}). The app reads User/<uid>, so a role set here has no effect.`
+                              : 'Another document shares this email. Only the one whose Doc ID equals the signed-in UID governs access — a role set on the other is ignored. The user can read their UID off the 403 page.'
+                          }
                         >
-                          stale doc
+                          check UID
                         </span>
                       )}
                     </td>

--- a/src/routes/ProtectedRoute/ProtectedRoute.js
+++ b/src/routes/ProtectedRoute/ProtectedRoute.js
@@ -18,7 +18,7 @@ import { canAccessCard } from 'src/services/roles/cards';
  */
 const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
   const { user, loading, error } = useAuth();
-  const { role, cards, loading: roleLoading } = useRole();
+  const { role, cards, loading: roleLoading, error: roleError, refresh } = useRole();
   const location = useLocation();
   const navigate = useNavigate();
   const storedEmptyFields = localStorage.getItem('empty_fields');
@@ -53,6 +53,31 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
     (requiredRoles && requiredRoles.length
       ? requiredRoles.reduce((hi, r) => (hasAtLeast(r, hi) ? r : hi), requiredRoles[0])
       : null);
+
+  // A failed role lookup is NOT a denial. Falling through here would tell a
+  // legitimate employee their role is "User" — the exact misdiagnosis that sent
+  // us hunting through Firestore documents that turned out to be correct. Say
+  // the check failed, show why, and offer a retry.
+  if (roleError && (effectiveMin || card)) {
+    return (
+      <div className="d-flex justify-content-center align-items-center min-vh-100 px-3">
+        <div className="text-center" style={{ maxWidth: 560 }}>
+          <h1 className="h3 fw-bold">Couldn&apos;t verify your access</h1>
+          <p className="text-muted">
+            We couldn&apos;t read your role from the server, so we don&apos;t know what you&apos;re
+            allowed to see. This is a connection or permissions problem, not a decision about your
+            account.
+          </p>
+          <p className="text-muted small">
+            Error: <code>{String(roleError)}</code>
+          </p>
+          <button type="button" className="btn btn-primary" onClick={refresh}>
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   // Pass the reason along so /not-authorized can say what's actually missing
   // instead of a bare 403 — the difference between "your role is too low" and

--- a/src/services/roles/RoleContext.jsx
+++ b/src/services/roles/RoleContext.jsx
@@ -7,12 +7,19 @@
 import React, { createContext, useContext, useEffect, useState, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useAuth } from '../../hooks/useAuth';
-import { ensureUserProfile, ROLES, hasAtLeast, canManageRoles } from './roles';
+import {
+  ensureUserProfile,
+  subscribeUserProfile,
+  ROLES,
+  hasAtLeast,
+  canManageRoles,
+} from './roles';
 import { canAccessCard, visibleCards } from './cards';
 
 const RoleContext = createContext({
   role: ROLES.USER,
   cards: [],
+  error: null,
   loading: true,
   refresh: () => {},
 });
@@ -22,6 +29,9 @@ export function RoleProvider({ children }) {
   const [role, setRole] = useState(ROLES.USER);
   const [cards, setCards] = useState([]);
   const [loading, setLoading] = useState(true);
+  // Non-null when the role lookup itself failed, as opposed to resolving to a
+  // genuine plain `user`. Consumers must not treat this as a denial.
+  const [error, setError] = useState(null);
   // Which uid the current role/cards were actually resolved for. Effects run
   // AFTER the render that follows a sign-in, so without this there is one
   // commit where `uid` is the new user but `role` is still the signed-out
@@ -51,6 +61,7 @@ export function RoleProvider({ children }) {
     const access = await ensureUserProfile(u);
     setRole(access.role);
     setCards(access.cards);
+    setError(access.error || null);
     setResolvedFor(u.uid);
     setLoading(false);
   }, []);
@@ -58,28 +69,48 @@ export function RoleProvider({ children }) {
   useEffect(() => {
     if (authLoading) return undefined;
     let cancelled = false;
+    let unsubscribe = () => {};
     (async () => {
       const u = userRef.current;
       if (!u) {
         if (!cancelled) {
           setRole(ROLES.USER);
           setCards([]);
+          setError(null);
           setResolvedFor(null);
           setLoading(false);
         }
         return;
       }
       setLoading(true);
+      // One read first: it creates the doc on first sign-in and honors the
+      // bootstrap superadmin, neither of which a listener can do.
       const access = await ensureUserProfile(u);
-      if (!cancelled) {
-        setRole(access.role);
-        setCards(access.cards);
-        setResolvedFor(u.uid);
-        setLoading(false);
-      }
+      if (cancelled) return;
+      setRole(access.role);
+      setCards(access.cards);
+      setError(access.error || null);
+      setResolvedFor(u.uid);
+      setLoading(false);
+
+      // Then keep it live, so an admin changing a role or granting a card takes
+      // effect in an open tab instead of waiting for the next sign-in.
+      unsubscribe = subscribeUserProfile(
+        u,
+        next => {
+          if (cancelled) return;
+          setRole(next.role);
+          setCards(next.cards);
+          setError(null);
+        },
+        err => {
+          if (!cancelled) setError(err);
+        }
+      );
     })();
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, [uid, authLoading]);
 
@@ -90,6 +121,7 @@ export function RoleProvider({ children }) {
   const value = {
     role,
     cards,
+    error,
     loading: loading || authLoading || stale,
     refresh: applyRole,
     isAtLeast: required => hasAtLeast(role, required),

--- a/src/services/roles/roles.js
+++ b/src/services/roles/roles.js
@@ -15,6 +15,7 @@ import {
   setDoc,
   updateDoc,
   getDocs,
+  onSnapshot,
   collection,
   serverTimestamp,
 } from 'firebase/firestore';
@@ -145,9 +146,39 @@ export async function ensureUserProfile(user) {
     );
     return fallback;
   } catch (e) {
+    // IMPORTANT: report the failure rather than only falling back. A denied or
+    // failed read used to be indistinguishable from "this person is a plain
+    // user", so an infrastructure problem surfaced as a confident 403 telling a
+    // real employee their role was User. Callers decide what to do with it.
     console.error('ensureUserProfile failed, using fallback access:', e);
-    return fallback;
+    return { ...fallback, error: e?.code || e?.message || String(e) };
   }
+}
+
+/**
+ * Watch a user's role/card grants and call `onChange` whenever they change.
+ * Without this the role resolves once per session, so an admin's change didn't
+ * reach an already-open tab until the user signed out and back in — which looks
+ * exactly like the change not having worked.
+ * Returns an unsubscribe function.
+ */
+export function subscribeUserProfile(user, onChange, onError) {
+  if (!user) return () => {};
+  const bootstrap = isBootstrapSuperadmin(user.email);
+  return onSnapshot(
+    doc(db, 'User', user.uid),
+    snap => {
+      const data = snap.exists() ? snap.data() : {};
+      onChange({
+        role: bootstrap ? ROLES.SUPERADMIN : data.role || ROLES.USER,
+        cards: data.cardAccess || [],
+      });
+    },
+    err => {
+      console.error('subscribeUserProfile failed:', err);
+      if (onError) onError(err?.code || err?.message || String(err));
+    }
+  );
 }
 
 /** List all users with their roles (for the management UI). Admin/superadmin only via rules. */


### PR DESCRIPTION
## Problem

An account whose Firestore document is demonstrably correct — doc id equal to the Firebase uid (`Wz1ZQNVgNGbvvy3KKZdhtf4UaHG2`), `role: "employee"`, a single Auth user, rules permitting the read — still hit a 403 claiming their role was **User**.

Two defects in this code make that possible, and both make it indistinguishable from a genuine denial:

1. **`ensureUserProfile` swallowed every read failure and returned `role: 'user'`.** For an authorization decision that's the wrong default direction. A connection blip or a denied read renders as a confident *"your role is User"*, which sends people auditing data that was never wrong — as happened here across two rounds of Firestore and IAM checks.

2. **The role resolved exactly once per session.** An admin promoting someone had no effect on an already-open tab until that user signed out and back in — visually identical to the promotion not working.

## Changes

- `ensureUserProfile` now returns an `error` alongside role/cards instead of only falling back.
- `RoleContext` exposes `error` and no longer conflates it with a resolved role.
- `ProtectedRoute` treats a lookup failure as a failure, not a denial: it renders **"Couldn't verify your access"** with the underlying Firestore error code and a **Try again** button, rather than a 403 asserting the user's role.
- New `subscribeUserProfile` keeps the role and card grants live via `onSnapshot` after the initial read, so an admin's change applies in an open tab. The one-shot read stays first because it creates the document on first sign-in and honors the bootstrap superadmin, neither of which a listener does.

## What this means for the open bug

Either the read is failing (the next screenshot will name the error code instead of lying about the role), or the tab was holding a role resolved before the promotion (now fixed by the live subscription). Both were invisible before this change.

## Testing

- `react-app-rewired build` — compiles, build folder ready.
- `eslint` — clean on all touched files.
- Not reproduced locally: the failure needs the live Firestore and the specific account, which this environment can't reach. These changes are what make the cause observable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_