### PR TITLE
Let the orphan prune run from CI, with guards

### DIFF
--- a/.github/workflows/prune-user-profiles.yml
+++ b/.github/workflows/prune-user-profiles.yml
@@ -1,0 +1,74 @@
+# Deletes User documents whose Firebase Auth account no longer exists.
+#
+# Manual only — this mutates production data, so it never runs on a push. The
+# default is a dry run; set apply=true to actually delete.
+#
+# Runs in --summary mode: this repository is public, so its CI logs are public,
+# and per-document output would put user emails and uids in them.
+name: Prune deleted-user profiles
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually delete (false = dry run, just counts)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prune-user-profiles
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install the Admin SDK
+        run: npm install --no-save --no-audit --no-fund firebase-admin@12
+
+      - name: Check the service account secret is present
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT is not set."
+            exit 1
+          fi
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
+
+      - name: Confirm the key targets anddhen
+        run: |
+          node -e '
+            const sa = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+            console.log("project_id:", sa.project_id);
+            if (sa.project_id !== "anddhen") {
+              console.log("::error::Key belongs to \"" + sa.project_id + "\", not \"anddhen\".");
+              process.exit(1);
+            }
+          '
+
+      - name: Prune
+        env:
+          GCLOUD_PROJECT: anddhen
+        run: |
+          node firestore/pruneDeletedUsers.js --summary \
+            ${{ inputs.apply && '--apply' || '' }}
+
+      - name: Remove credentials from the runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"

--- a/firestore/pruneDeletedUsers.js
+++ b/firestore/pruneDeletedUsers.js
@@ -16,10 +16,19 @@
 const admin = require('firebase-admin');
 const path = require('path');
 
-const serviceAccount = require(path.join(__dirname, 'serviceAccount.json'));
-admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+// Local runs use firestore/serviceAccount.json; CI has no such file and supplies
+// the key through GOOGLE_APPLICATION_CREDENTIALS instead.
+let credential;
+try {
+  credential = admin.credential.cert(require(path.join(__dirname, 'serviceAccount.json')));
+} catch (e) {
+  credential = admin.credential.applicationDefault();
+}
+admin.initializeApp({ credential, projectId: process.env.GCLOUD_PROJECT || 'anddhen' });
 
 const apply = process.argv.includes('--apply');
+// CI logs on a public repo are public: print counts only, never emails or uids.
+const summary = process.argv.includes('--summary');
 
 /** Every uid that currently has an Auth account (paginated, 1000 per page). */
 async function allAuthUids() {
@@ -39,6 +48,12 @@ async function run() {
     admin.firestore().collection('User').get(),
   ]);
 
+  // Refuse to act on an empty account list: a partial or failed listUsers would
+  // otherwise class every profile as an orphan and wipe the collection.
+  if (authUids.size === 0) {
+    throw new Error('No Auth accounts returned — refusing to treat every profile as orphaned.');
+  }
+
   const orphans = snap.docs.filter(d => !authUids.has(d.id));
 
   console.log(`Auth accounts: ${authUids.size}`);
@@ -47,10 +62,21 @@ async function run() {
 
   if (orphans.length === 0) return;
 
-  orphans.forEach(d => {
-    const data = d.data();
-    console.log(`  ${d.id}  ${data.email_id || '(no email)'}  role=${data.role || 'user'}`);
-  });
+  // Deleting every document means the uid comparison is wrong, not that every
+  // account was deleted. Require an explicit override rather than guessing.
+  if (orphans.length === snap.size && !process.argv.includes('--force-all')) {
+    throw new Error(
+      `Every one of the ${snap.size} profiles looks orphaned. That is almost certainly a bug, ` +
+        'not reality. Re-run with --force-all if you really mean it.'
+    );
+  }
+
+  if (!summary) {
+    orphans.forEach(d => {
+      const data = d.data();
+      console.log(`  ${d.id}  ${data.email_id || '(no email)'}  role=${data.role || 'user'}`);
+    });
+  }
 
   if (!apply) {
     console.log('\nDry run — nothing deleted. Re-run with --apply to remove these.');


### PR DESCRIPTION
## Why

`pruneDeletedUsers.js` could only run from a machine holding `firestore/serviceAccount.json`. The repo's existing `FIREBASE_SERVICE_ACCOUNT` secret already carries **Firebase Authentication Admin** and **Admin SDK** access — exactly what the script needs — so the same job can run in Actions and the cleanup stops depending on someone having a key locally.

## Changes

**`pruneDeletedUsers.js`**
- Falls back to application-default credentials (`GOOGLE_APPLICATION_CREDENTIALS`) when `serviceAccount.json` isn't present, so it works locally and in CI unchanged.
- **Guard: abort if `listUsers` returns nothing.** A partial or failed listing would otherwise classify every profile as orphaned and empty the collection.
- **Guard: abort if every profile looks orphaned.** That means the uid comparison is broken, not that every account was deleted. `--force-all` overrides.
- `--summary` mode prints counts only. This repository is public, so its CI logs are public, and per-document output would put user emails and uids in them.

**`.github/workflows/prune-user-profiles.yml`**
- `workflow_dispatch` only — this mutates production data, so it never runs on a push.
- Dry run by default; deleting needs `apply=true`.
- Always `--summary`, for the log-privacy reason above.
- Refuses to run if the key belongs to a project other than `anddhen` (the same check that caught the `indimitra` key earlier).

## Testing

- Workflow YAML parses; 8 steps resolve.
- `node --check` passes on the script.
- The guards are unexercised here — they need live Auth and Firestore, which this environment can't reach. They're written to fail closed: every uncertain case throws rather than deleting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_