### PR TITLE
Share one auth subscription, so login stops 403ing valid users

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,27 +1,49 @@
 import { useState, useEffect } from 'react';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 
+/**
+ * Shared auth state.
+ *
+ * This used to be a plain hook: every component that called it created its own
+ * useState and its own onAuthStateChanged subscription. At sign-in each copy
+ * updated independently, so for a moment ProtectedRoute could see a signed-in
+ * user while RoleProvider still saw nobody — and a real employee got bounced to
+ * /not-authorized on login while the same URL typed by hand worked fine.
+ *
+ * One module-level subscription, one snapshot, every consumer notified in the
+ * same React batch. The hook's shape is unchanged, so callers don't care.
+ */
+let snapshot = { user: null, loading: true, error: null };
+const subscribers = new Set();
+let started = false;
+
+const emit = next => {
+  snapshot = next;
+  subscribers.forEach(fn => fn(snapshot));
+};
+
+// Started lazily from the first useEffect, which guarantees the Firebase app is
+// initialized by then (index.js imports it before rendering).
+function startOnce() {
+  if (started) return;
+  started = true;
+  onAuthStateChanged(
+    getAuth(),
+    user => emit({ user, loading: false, error: null }),
+    error => emit({ user: null, loading: false, error })
+  );
+}
+
 export const useAuth = () => {
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [state, setState] = useState(snapshot);
 
   useEffect(() => {
-    const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(
-      auth,
-      user => {
-        setUser(user);
-        setLoading(false);
-      },
-      error => {
-        setError(error);
-        setLoading(false);
-      }
-    );
-
-    return () => unsubscribe();
+    startOnce();
+    subscribers.add(setState);
+    // Catch up if auth resolved between this component's render and its effect.
+    setState(snapshot);
+    return () => subscribers.delete(setState);
   }, []);
 
-  return { user, loading, error };
+  return state;
 };

--- a/src/routes/ProtectedRoute/ProtectedRoute.js
+++ b/src/routes/ProtectedRoute/ProtectedRoute.js
@@ -18,7 +18,7 @@ import { canAccessCard } from 'src/services/roles/cards';
  */
 const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
   const { user, loading, error } = useAuth();
-  const { role, cards, loading: roleLoading, error: roleError, refresh } = useRole();
+  const { role, cards, loading: roleLoading, error: roleError, refresh, roleUid } = useRole();
   const location = useLocation();
   const navigate = useNavigate();
   const storedEmptyFields = localStorage.getItem('empty_fields');
@@ -41,8 +41,10 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
     return <Navigate to="/login" replace />;
   }
 
-  // Wait for the role to resolve before making an access decision.
-  if (roleLoading) {
+  // Wait for the role to resolve before making an access decision — and for it
+  // to have been resolved for THIS user. A role belonging to nobody (the
+  // signed-out default) or to a previous session must never be judged.
+  if (roleLoading || roleUid !== user.uid) {
     return <LoadingSpinner />;
   }
 

--- a/src/services/roles/RoleContext.jsx
+++ b/src/services/roles/RoleContext.jsx
@@ -122,6 +122,10 @@ export function RoleProvider({ children }) {
     role,
     cards,
     error,
+    // The uid these values were resolved for. Consumers hold their own view of
+    // who is signed in; comparing against this is the only way to know the role
+    // in hand actually belongs to the user they are gating.
+    roleUid: resolvedFor,
     loading: loading || authLoading || stale,
     refresh: applyRole,
     isAtLeast: required => hasAtLeast(role, required),


### PR DESCRIPTION
## Root cause

`useAuth` was a plain hook: **every component that called it created its own `useState` and its own `onAuthStateChanged` subscription.** `RoleProvider` and `ProtectedRoute` therefore held independent views of who was signed in, and at sign-in they updated in separate commits.

That defeated the staleness guard from #244. It compared `resolvedFor` against `RoleProvider`'s *own* uid — but when `ProtectedRoute`'s listener fired first:

| | `ProtectedRoute` | `RoleProvider` |
| --- | --- | --- |
| `user` / `uid` | signed-in user | still `null` |
| `resolvedFor` | — | `null` |
| → `stale` | — | `false` (both null, so "matching") |
| → `roleLoading` | `false` | |

The guard waved through the signed-out default role, and a legitimate employee got `/not-authorized` on login. The same URL typed by hand worked, because by then both copies had settled — exactly the reported symptom.

## Changes

**`useAuth`** is now backed by one module-level subscription and a single shared snapshot, so every consumer updates in the same React batch and the two can no longer disagree. The hook's return shape is unchanged, so no caller changes. It starts lazily from the first effect, which guarantees the Firebase app is initialized by then.

**Closed the hole as well as its cause**, since a single stale read shouldn't be able to deny access again: `RoleContext` exposes `roleUid` — the uid its role and cards were resolved for — and `ProtectedRoute` waits until that matches the user it's actually gating. A role belonging to nobody, or to a previous session, is never judged.

## Testing

- `react-app-rewired build` — compiles, build folder ready.
- `eslint` — clean on all three touched files.
- Not reproduced end-to-end here: it needs a live sign-in against Firebase, which this environment can't do. The diagnosis comes from the interleaving above, and it matches the symptom precisely — fails on login, works on manual navigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_