### PR TITLE
Instrument the login sequence instead of guessing at it

### DIFF
--- a/.github/workflows/read-auth-trace.yml
+++ b/.github/workflows/read-auth-trace.yml
@@ -1,0 +1,70 @@
+# Prints the sign-in traces written by src/services/roles/authTrace.js, so the
+# 403-on-login ordering can be read rather than guessed at.
+#
+# Read-only. Emails are never printed and uids are truncated: this repository
+# is public, so its CI logs are public.
+name: Read auth traces
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'How many recent traces to print'
+        type: string
+        default: '5'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: read-auth-trace
+  cancel-in-progress: false
+
+jobs:
+  read:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install the Admin SDK
+        run: npm install --no-save --no-audit --no-fund firebase-admin@12
+
+      - name: Check the service account secret is present
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT is not set."
+            exit 1
+          fi
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
+
+      - name: Confirm the key targets anddhen
+        run: |
+          node -e '
+            const sa = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+            console.log("project_id:", sa.project_id);
+            if (sa.project_id !== "anddhen") {
+              console.log("::error::Key belongs to \"" + sa.project_id + "\", not \"anddhen\".");
+              process.exit(1);
+            }
+          '
+
+      - name: Read traces
+        env:
+          GCLOUD_PROJECT: anddhen
+        run: node firestore/readAuthTrace.js "${{ inputs.limit }}"
+
+      - name: Remove credentials from the runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"

--- a/firestore/readAuthTrace.js
+++ b/firestore/readAuthTrace.js
@@ -1,0 +1,56 @@
+/**
+ * Print the most recent sign-in traces written by src/services/roles/authTrace.js.
+ *
+ * The 403-on-login failure only happens in the live app, so this is how the
+ * actual ordering gets read rather than reasoned about.
+ *
+ * Usage:
+ *   node firestore/readAuthTrace.js          # 5 most recent traces
+ *   node firestore/readAuthTrace.js 20       # 20 most recent
+ *
+ * Emails are never printed — this runs in CI on a public repository, and the
+ * event sequence is what matters, not who produced it.
+ */
+const admin = require('firebase-admin');
+const path = require('path');
+
+let credential;
+try {
+  credential = admin.credential.cert(require(path.join(__dirname, 'serviceAccount.json')));
+} catch (e) {
+  credential = admin.credential.applicationDefault();
+}
+admin.initializeApp({ credential, projectId: process.env.GCLOUD_PROJECT || 'anddhen' });
+
+const limit = Number(process.argv[2]) || 5;
+
+async function run() {
+  const snap = await admin
+    .firestore()
+    .collection('debugAuthTrace')
+    .orderBy('createdAt', 'desc')
+    .limit(limit)
+    .get();
+
+  if (snap.empty) {
+    console.log('No traces yet. Visit the site with ?trace=1, then sign in.');
+    return;
+  }
+
+  snap.docs.forEach((doc, i) => {
+    const d = doc.data();
+    console.log(`\n=== trace ${i + 1}/${snap.size} — ${d.reason} @ ${d.path} ===`);
+    console.log(`uid ${String(d.uid).slice(0, 6)}…  ${d.userAgent || ''}`);
+    (d.events || []).forEach(e => {
+      const { ms, name, ...rest } = e;
+      console.log(`  ${String(ms).padStart(6)}ms  ${name.padEnd(20)} ${JSON.stringify(rest)}`);
+    });
+  });
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error('Failed:', err.message);
+    process.exit(1);
+  });

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import { trace } from '../services/roles/authTrace';
 
 /**
  * Shared auth state.
@@ -29,8 +30,14 @@ function startOnce() {
   started = true;
   onAuthStateChanged(
     getAuth(),
-    user => emit({ user, loading: false, error: null }),
-    error => emit({ user: null, loading: false, error })
+    user => {
+      trace('auth:changed', { uid: user ? user.uid : null, subscribers: subscribers.size });
+      emit({ user, loading: false, error: null });
+    },
+    error => {
+      trace('auth:error', { error: String(error && error.code) });
+      emit({ user: null, loading: false, error });
+    }
   );
 }
 

--- a/src/routes/ProtectedRoute/ProtectedRoute.js
+++ b/src/routes/ProtectedRoute/ProtectedRoute.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { useRole } from 'src/services/roles/RoleContext';
 import { hasAtLeast } from 'src/services/roles/roles';
 import { canAccessCard } from 'src/services/roles/cards';
+import { trace, flushTrace } from 'src/services/roles/authTrace';
 
 /**
  * Route guard driven by the Firebase role system.
@@ -30,11 +31,25 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
     }
   }, [storedEmptyFields, navigate, location.pathname]);
 
+  trace('guard:render', {
+    path: location.pathname,
+    minRole: minRole || null,
+    card: card || null,
+    authLoading: loading,
+    roleLoading,
+    userUid: user ? user.uid : null,
+    roleUid: roleUid || null,
+    role,
+    cards: (cards || []).length,
+  });
+
   if ((loading || roleLoading) && !user) {
+    trace('guard:wait', { why: 'auth' });
     return <LoadingSpinner />;
   }
 
   if (error || !user) {
+    trace('guard:tologin', { authError: String(error || ''), hasUser: !!user });
     if (location.pathname !== '/profile') {
       localStorage.setItem('preLoginPath', location.pathname);
     }
@@ -45,6 +60,7 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
   // to have been resolved for THIS user. A role belonging to nobody (the
   // signed-out default) or to a previous session must never be judged.
   if (roleLoading || roleUid !== user.uid) {
+    trace('guard:wait', { why: roleLoading ? 'roleLoading' : 'uidMismatch' });
     return <LoadingSpinner />;
   }
 
@@ -85,6 +101,8 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
   // instead of a bare 403 — the difference between "your role is too low" and
   // "nobody granted you this card" is the difference between two fixes.
   if (effectiveMin && !hasAtLeast(role, effectiveMin)) {
+    trace('guard:deny:role', { role, required: effectiveMin });
+    flushTrace('deny:role', user);
     return (
       <Navigate
         to="/not-authorized"
@@ -96,6 +114,8 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
 
   // The role opens the dashboard; the grant opens the individual card.
   if (card && !canAccessCard(role, cards, card)) {
+    trace('guard:deny:card', { role, card });
+    flushTrace('deny:card', user);
     return (
       <Navigate
         to="/not-authorized"
@@ -111,6 +131,8 @@ const ProtectedRoute = ({ children, minRole, card, requiredRoles }) => {
     );
   }
 
+  trace('guard:allow', { role, path: location.pathname });
+  flushTrace('allow', user);
   return children;
 };
 

--- a/src/services/roles/RoleContext.jsx
+++ b/src/services/roles/RoleContext.jsx
@@ -15,6 +15,7 @@ import {
   canManageRoles,
 } from './roles';
 import { canAccessCard, visibleCards } from './cards';
+import { trace } from './authTrace';
 
 const RoleContext = createContext({
   role: ROLES.USER,
@@ -74,6 +75,7 @@ export function RoleProvider({ children }) {
       const u = userRef.current;
       if (!u) {
         if (!cancelled) {
+          trace('role:signedout');
           setRole(ROLES.USER);
           setCards([]);
           setError(null);
@@ -83,10 +85,17 @@ export function RoleProvider({ children }) {
         return;
       }
       setLoading(true);
+      trace('role:resolve:start', { uid: u.uid });
       // One read first: it creates the doc on first sign-in and honors the
       // bootstrap superadmin, neither of which a listener can do.
       const access = await ensureUserProfile(u);
       if (cancelled) return;
+      trace('role:resolve:done', {
+        uid: u.uid,
+        role: access.role,
+        cards: (access.cards || []).length,
+        error: access.error || null,
+      });
       setRole(access.role);
       setCards(access.cards);
       setError(access.error || null);

--- a/src/services/roles/authTrace.js
+++ b/src/services/roles/authTrace.js
@@ -1,0 +1,67 @@
+/**
+ * Diagnostic trace for the sign-in → role-resolution → route-guard sequence.
+ *
+ * Three fixes for "403 on login" have been reasoned about rather than
+ * measured, and the failure can't be reproduced outside the live app. This
+ * records what actually happens, in order, with timings, and posts it to
+ * Firestore where it can be read back with the Admin SDK.
+ *
+ * OFF by default. Enable per-browser by visiting any page with `?trace=1`
+ * (disable with `?trace=0`), so this never writes for ordinary visitors.
+ * Events accumulate in memory and are flushed as ONE document per session when
+ * the guard reaches a decision — writes require a signed-in user, and one doc
+ * beats a write per event.
+ */
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { db } from '../connector/firebase';
+
+const KEY = 'authTrace';
+const COLLECTION = 'debugAuthTrace';
+const t0 = Date.now();
+
+const events = [];
+let flushed = false;
+
+function enabled() {
+  try {
+    const param = new URLSearchParams(window.location.search).get('trace');
+    if (param === '1') localStorage.setItem(KEY, '1');
+    if (param === '0') localStorage.removeItem(KEY);
+    return localStorage.getItem(KEY) === '1';
+  } catch (e) {
+    return false;
+  }
+}
+
+/** Record a step. Cheap and side-effect free when tracing is off. */
+export function trace(name, data = {}) {
+  if (!enabled()) return;
+  const entry = { ms: Date.now() - t0, name, ...data };
+  events.push(entry);
+  // Also to the console, so it's visible without a round trip to Firestore.
+  console.log('[authTrace]', entry);
+}
+
+/**
+ * Write the accumulated trace as a single document. Called when the guard
+ * decides, which is the moment worth explaining. Runs at most once per page
+ * load, and never throws — diagnostics must not break the page they observe.
+ */
+export async function flushTrace(reason, user) {
+  if (!enabled() || flushed || !user) return;
+  flushed = true;
+  try {
+    await addDoc(collection(db, COLLECTION), {
+      uid: user.uid,
+      email: user.email || '',
+      reason,
+      path: window.location.pathname,
+      userAgent: navigator.userAgent.slice(0, 200),
+      events,
+      createdAt: serverTimestamp(),
+    });
+    console.log('[authTrace] flushed', reason, events.length, 'events');
+  } catch (e) {
+    console.warn('[authTrace] flush failed', e);
+  }
+}


### PR DESCRIPTION
## Why

Three fixes for "403 on login" have been argued from reading the code, none verified, and the last one didn't work. The failure only occurs in the live app against real Firebase, which this environment can't reach. The next change should follow evidence.

**No behaviour change in this PR.** The candidate fix this PR previously contained (one atomic identity+access snapshot) is deliberately excluded so it can't confound the measurement — it's preserved at commit `be12525` and can be reapplied once the trace says whether it's the right fix.

## What it records

`src/services/roles/authTrace.js` captures the sequence with timings:

- `auth:changed` — when `onAuthStateChanged` fires, and with which uid
- `role:resolve:start` / `role:resolve:done` — with the resolved role, card count, and any error
- `guard:render` — **every** render of the route guard with the exact inputs it decided on: `authLoading`, `roleLoading`, the uid it sees, the uid the role belongs to, and the role
- `guard:wait` / `guard:tologin` / `guard:deny:role` / `guard:deny:card` / `guard:allow`

The whole session flushes as one Firestore document (`debugAuthTrace`) the moment the guard allows or denies — the instant worth explaining. That ordering is exactly what my last three diagnoses were speculating about.

**Off unless a browser opts in with `?trace=1`** (`?trace=0` disables), so it never writes for ordinary visitors. It mirrors to the console too, and never throws — diagnostics must not break the page they observe. No rules change needed: the catch-all already lets a signed-in user create in a non-admin collection.

## Reading it back

`firestore/readAuthTrace.js` and a **Read auth traces** workflow print them through the Admin SDK — the same path the prune job already uses. Emails are never printed and uids are truncated, since this repo's CI logs are public.

## How to use it

1. Open `https://anddhengroup.com/login?trace=1`
2. Sign in and let it land on the 403
3. I run the workflow and read the actual ordering

## Testing

- `react-app-rewired build` — compiles, build folder ready.
- `eslint` — clean across `services/roles`, `hooks`, `routes`.
- Workflow YAML parses; `node --check` passes on the reader.
- The trace itself can only be validated by producing one, which is the next step.