### PR TITLE
Carry the role in the ID token as a custom claim

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -17,7 +17,14 @@ on:
       - 'functions/**'
       - '.github/workflows/deploy-functions.yml'
   # Lets you deploy without pushing a commit (Actions tab > Run workflow).
+  # `only` narrows the deploy: functions:syncRoleClaim ships the role-claim
+  # sync alone, which needs no OPENAI_API_KEY because it binds no secret.
   workflow_dispatch:
+    inputs:
+      only:
+        description: 'Deploy target (e.g. functions, or functions:syncRoleClaim)'
+        type: string
+        default: functions
 
 permissions:
   contents: read
@@ -77,9 +84,11 @@ jobs:
           '
 
       - name: Deploy functions
+        env:
+          ONLY: ${{ inputs.only || 'functions' }}
         run: |
           npx --yes firebase-tools@15 deploy \
-            --only functions \
+            --only "$ONLY" \
             --project anddhen \
             --non-interactive
 

--- a/.github/workflows/sync-role-claims.yml
+++ b/.github/workflows/sync-role-claims.yml
@@ -1,0 +1,75 @@
+# Copies each user's Firestore role into their `role` custom auth claim.
+#
+# Needed because the syncRoleClaim Cloud Function only fires on future writes,
+# and can't deploy until Cloud Functions are unblocked. This covers everyone who
+# already exists, and needs only Firebase Authentication Admin — which the CI
+# key already has — so claims work before functions do.
+#
+# Manual only, dry run by default. Re-runnable: matching claims are skipped.
+name: Sync role claims
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually write claims (false = dry run, just counts)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-role-claims
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install the Admin SDK
+        run: npm install --no-save --no-audit --no-fund firebase-admin@12
+
+      - name: Check the service account secret is present
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT is not set."
+            exit 1
+          fi
+
+      - name: Write service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-service-account.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
+
+      - name: Confirm the key targets anddhen
+        run: |
+          node -e '
+            const sa = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+            console.log("project_id:", sa.project_id);
+            if (sa.project_id !== "anddhen") {
+              console.log("::error::Key belongs to \"" + sa.project_id + "\", not \"anddhen\".");
+              process.exit(1);
+            }
+          '
+
+      - name: Sync claims
+        env:
+          GCLOUD_PROJECT: anddhen
+        run: |
+          node firestore/syncRoleClaims.js \
+            ${{ inputs.apply && '--apply' || '' }}
+
+      - name: Remove credentials from the runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-service-account.json"

--- a/firestore.rules
+++ b/firestore.rules
@@ -15,10 +15,20 @@ service cloud.firestore {
       return request.auth != null;
     }
 
-    // Role of the CURRENT requester (defaults to 'user' if their doc/field is absent).
+    // Role of the CURRENT requester.
+    //
+    // Prefers the `role` custom claim, which rides in the ID token and costs
+    // nothing to read. The get() fallback stays for accounts whose claim hasn't
+    // been synced yet (see functions syncRoleClaim and
+    // firestore/syncRoleClaims.js) — dropping it would lock those users out,
+    // and it costs a billed document read on every evaluation that needs it.
     function myRole() {
       let path = /databases/$(database)/documents/User/$(request.auth.uid);
-      return signedIn() && exists(path) ? get(path).data.get('role', 'user') : 'user';
+      return !signedIn()
+        ? 'user'
+        : request.auth.token.get('role', '') != ''
+          ? request.auth.token.role
+          : (exists(path) ? get(path).data.get('role', 'user') : 'user');
     }
 
     // Bootstrap superadmin(s) by email — keep in sync with SUPERADMIN_EMAILS in

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -101,3 +101,45 @@ Point the app at emulators by setting `REACT_APP_USE_EMULATORS=true` (wire-up TO
    or set `REACT_APP_DATA_PROVIDER=firebase`.
 
 See `firestore/schema.md` for the full 21-collection field map.
+
+## Roles in the ID token (custom claims)
+
+`User/{uid}.role` stays the source of truth — it's what the admin UI writes and
+what a browser can change without the Admin SDK. The `role` **custom claim** is a
+copy of it that rides in the ID token, which buys two things Firestore can't:
+
+- **Security rules read `request.auth.token.role`** instead of a `get()` on the
+  user's document — no billed read, no round trip, on every evaluation.
+- **The client knows the role the moment it knows the identity**, rather than
+  doing a second async lookup that can be observed mid-flight.
+
+`myRole()` in `firestore.rules` prefers the claim and falls back to the document,
+so accounts whose claim hasn't synced yet keep working rather than being locked
+out. `roleFromToken()` on the client does the same.
+
+### Keeping claims in step
+
+| When | What updates the claim |
+| --- | --- |
+| Any write to `User/{uid}` | the `syncRoleClaim` Cloud Function (needs functions deployed) |
+| Existing users, or before functions deploy | **Sync role claims** workflow, or `node firestore/syncRoleClaims.js --apply` |
+
+Both write `claimsUpdatedAt` on the profile. The client watches that document, so
+the change wakes its listener, which force-refreshes the ID token — a new role
+applies immediately instead of waiting out the token's hour.
+
+Setting a claim needs only **Firebase Authentication Admin**, which the CI service
+account already has: claims work before Cloud Functions do. The function only
+makes it automatic.
+
+### Unblocking the Cloud Function
+
+Three things, none of which CI can do for itself:
+
+1. **Blaze billing** on the project — v2 functions build a container; Spark refuses.
+2. **IAM roles** on the deploy principal: `Cloud Functions Admin`, `Cloud Run Admin`,
+   `Service Account User`, `Artifact Registry Administrator`, `Cloud Build Editor`,
+   `Service Usage Consumer`.
+3. Nothing else for this function — deploy it alone with
+   **Deploy Cloud Functions** → `only: functions:syncRoleClaim`. It binds no
+   secret, so `OPENAI_API_KEY` is only needed for the AI callables.

--- a/firestore/syncRoleClaims.js
+++ b/firestore/syncRoleClaims.js
@@ -1,0 +1,82 @@
+/**
+ * Set each user's `role` custom claim from their Firestore profile.
+ *
+ * The syncRoleClaim Cloud Function keeps claims current from here on, but it
+ * only fires on future writes and can't deploy until Cloud Functions are
+ * unblocked. This does the same job for everyone who already exists, and
+ * needs nothing but a service account with Firebase Authentication Admin —
+ * which the CI key already has. So claims work before functions do.
+ *
+ * Safe to re-run: accounts whose claim already matches are skipped.
+ *
+ * Usage (from Anddhen-Group/):
+ *   node firestore/syncRoleClaims.js            # dry run — counts only
+ *   node firestore/syncRoleClaims.js --apply    # write the claims
+ */
+const admin = require('firebase-admin');
+const path = require('path');
+
+let credential;
+try {
+  credential = admin.credential.cert(require(path.join(__dirname, 'serviceAccount.json')));
+} catch (e) {
+  credential = admin.credential.applicationDefault();
+}
+admin.initializeApp({ credential, projectId: process.env.GCLOUD_PROJECT || 'anddhen' });
+
+const apply = process.argv.includes('--apply');
+const VALID = ['user', 'employee', 'admin', 'superadmin'];
+
+async function run() {
+  const snap = await admin.firestore().collection('User').get();
+  console.log(`User documents: ${snap.size}`);
+
+  let changed = 0;
+  let skipped = 0;
+  let missing = 0;
+  let invalid = 0;
+
+  for (const doc of snap.docs) {
+    const role = doc.data().role || 'user';
+    if (!VALID.includes(role)) {
+      invalid += 1;
+      console.log(`  skipping ${doc.id.slice(0, 6)}… — unrecognised role "${role}"`);
+      continue;
+    }
+
+    let record;
+    try {
+      record = await admin.auth().getUser(doc.id);
+    } catch (e) {
+      // An orphaned profile — no account to carry a claim.
+      missing += 1;
+      continue;
+    }
+
+    if ((record.customClaims || {}).role === role) {
+      skipped += 1;
+      continue;
+    }
+
+    changed += 1;
+    if (apply) {
+      await admin.auth().setCustomUserClaims(doc.id, { role });
+      // Signals the client to refresh its token instead of waiting out the
+      // token's natural lifetime.
+      await doc.ref.set({ claimsUpdatedAt: Date.now() }, { merge: true });
+    }
+  }
+
+  console.log(`Already correct: ${skipped}`);
+  console.log(`No auth account: ${missing}`);
+  if (invalid) console.log(`Unrecognised role: ${invalid}`);
+  console.log(`${apply ? 'Updated' : 'Would update'}: ${changed}`);
+  if (!apply && changed) console.log('\nDry run — re-run with --apply to write these claims.');
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error('Failed:', err.message);
+    process.exit(1);
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -304,3 +304,56 @@ exports.cleanupUserProfile = functionsV1.auth.user().onDelete(async user => {
     console.error(`Failed to delete User/${user.uid}:`, e);
   }
 });
+
+/**
+ * Mirror User/{uid}.role into a custom auth claim.
+ *
+ * Firestore stays the source of truth — it's what the admin UI writes and what
+ * a browser can change without the Admin SDK. The claim is a copy that rides
+ * along in the ID token, which buys two things Firestore can't:
+ *   - security rules read `request.auth.token.role` instead of a get() on the
+ *     user's doc, saving a billed read and a round trip on every evaluation;
+ *   - the client knows the role the moment it knows the identity, with no
+ *     second async lookup that can be observed mid-flight.
+ *
+ * Only writes when the role actually changed: setCustomUserClaims invalidates
+ * nothing by itself, but every call is an Auth write, and doc updates that
+ * touch other fields are far more common than role changes.
+ *
+ * Existing users get their claim from firestore/syncRoleClaims.js — this
+ * trigger only fires on future writes.
+ */
+exports.syncRoleClaim = functionsV1.firestore
+  .document('User/{uid}')
+  .onWrite(async (change, context) => {
+    const { uid } = context.params;
+    const before = change.before.exists ? change.before.data() : null;
+    const after = change.after.exists ? change.after.data() : null;
+
+    const previous = before ? before.role || 'user' : null;
+    const next = after ? after.role || 'user' : null;
+    if (previous === next) return null;
+
+    try {
+      if (!after) {
+        // Document deleted. Clearing the claim keeps a re-created profile from
+        // inheriting the old role via a token that outlives the document.
+        await admin.auth().setCustomUserClaims(uid, null);
+        console.log(`Cleared role claim for ${uid}`);
+        return null;
+      }
+      await admin.auth().setCustomUserClaims(uid, { role: next });
+      // Bump a field the client watches, so it knows to refresh its token
+      // rather than waiting up to an hour for the natural refresh.
+      await db.doc(`User/${uid}`).set({ claimsUpdatedAt: Date.now() }, { merge: true });
+      console.log(`Set role claim for ${uid}: ${previous} -> ${next}`);
+    } catch (e) {
+      // A missing Auth account is expected for an orphaned profile.
+      if (e && e.code === 'auth/user-not-found') {
+        console.log(`No auth account for ${uid}; nothing to claim.`);
+        return null;
+      }
+      console.error(`Failed to sync role claim for ${uid}:`, e);
+    }
+    return null;
+  });

--- a/src/services/roles/roles.js
+++ b/src/services/roles/roles.js
@@ -115,7 +115,11 @@ export async function ensureUserProfile(user) {
 
     if (snap.exists()) {
       const data = snap.data();
-      const stored = data.role || ROLES.USER;
+      // Prefer the claim: same value, but it came with the token rather than
+      // from a lookup, and it's what security rules will judge. Fall back to
+      // the document whenever the claim hasn't been synced for this account.
+      const claimed = await roleFromToken(user);
+      const stored = claimed || data.role || ROLES.USER;
       const cards = data.cardAccess || [];
       // Promote a bootstrap superadmin whose stored role hasn't caught up yet.
       if (bootstrap && stored !== ROLES.SUPERADMIN) {
@@ -157,6 +161,30 @@ export async function ensureUserProfile(user) {
 }
 
 /**
+ * Read the role from the user's ID token.
+ *
+ * The claim is written by the syncRoleClaim function (or the backfill script)
+ * from the same Firestore field, so it says the same thing — it just arrives
+ * with the identity instead of needing a second lookup. Returns null when the
+ * account has no claim yet, so callers fall back to Firestore rather than
+ * treating an un-synced user as a plain `user`.
+ *
+ * `force` re-fetches the token, which is how a role change reaches a session
+ * that already holds an older one.
+ */
+export async function roleFromToken(user, force = false) {
+  if (!user) return null;
+  try {
+    const token = await user.getIdTokenResult(force);
+    const claim = token && token.claims && token.claims.role;
+    return RANK[claim] !== undefined ? claim : null;
+  } catch (e) {
+    console.error('roleFromToken failed:', e);
+    return null;
+  }
+}
+
+/**
  * Watch a user's role/card grants and call `onChange` whenever they change.
  * Without this the role resolves once per session, so an admin's change didn't
  * reach an already-open tab until the user signed out and back in — which looks
@@ -168,10 +196,15 @@ export function subscribeUserProfile(user, onChange, onError) {
   const bootstrap = isBootstrapSuperadmin(user.email);
   return onSnapshot(
     doc(db, 'User', user.uid),
-    snap => {
+    async snap => {
       const data = snap.exists() ? snap.data() : {};
+      // The document changed, so the claim may have too — the sync writes
+      // claimsUpdatedAt precisely to wake this up. Force a token refresh so a
+      // role change lands now instead of at the token's natural expiry, and
+      // prefer the refreshed claim over the field it was copied from.
+      const claimed = await roleFromToken(user, true);
       onChange({
-        role: bootstrap ? ROLES.SUPERADMIN : data.role || ROLES.USER,
+        role: bootstrap ? ROLES.SUPERADMIN : claimed || data.role || ROLES.USER,
         cards: data.cardAccess || [],
       });
     },


### PR DESCRIPTION
## What this gives you

Firestore stays the **source of truth** — it's what the admin UI writes and what a browser can change without the Admin SDK. The claim is a *copy* that rides in the ID token, which buys two things a document can't:

- **Security rules read `request.auth.token.role`** instead of a `get()` on the user's doc — no billed read, no round trip, on every evaluation.
- **The client knows the role the moment it knows the identity** — no second async lookup that can be observed mid-flight.

## Claims don't have to wait for Cloud Functions

Setting a claim needs only **Firebase Authentication Admin**, which the CI service account already holds. So `firestore/syncRoleClaims.js` + a **Sync role claims** workflow can populate every existing account **today**, with functions still blocked.

The `syncRoleClaim` function only makes it automatic for future writes. It's also scoped so it can deploy *alone* — it binds no secret, so `OPENAI_API_KEY` remains a concern of the AI callables only. `Deploy Cloud Functions` now takes an `only` input for that.

## Nothing is forced to have a claim

`myRole()` in the rules and `roleFromToken()` on the client both **prefer the claim and fall back to the document**, so un-synced accounts keep working instead of being locked out mid-rollout.

## Role changes still apply immediately

Both sync paths stamp `claimsUpdatedAt` on the profile. That wakes the client's existing document listener, which force-refreshes the ID token — so a new role lands at once rather than waiting out the token's hour. This was the main cost of claims, and it's paid for.

## Testing

Rules verified against the Firestore emulator — **5/5**:

```
PASS  claim role=admin can set another user's role
PASS  no claim, doc role=admin still works (fallback)
PASS  claim role=employee cannot change a role
PASS  employee cannot self-grant cardAccess
PASS  signed-in user can read a User doc
```

The first two are the ones that matter: a claim of `admin` grants admin even when the document says `user` (the claim is really being read), and an account with no claim still resolves through the document (the rollout is safe).

- `react-app-rewired build` — compiles.
- `eslint` — no errors in any file touched here; the 3 repo-wide errors are pre-existing in untouched files.
- `node --check` passes on the function and the sync script.

## What you still have to do

| | Who |
| --- | --- |
| Run **Sync role claims** (dry run, then `apply`) | me, on your word |
| **Blaze billing** on `anddhen` | you — needs a payment method |
| 6 IAM roles on the deploy principal (listed in `firestore/README.md`) | you — needs `setIamPolicy`, which the CI key lacks |
| Deploy `functions:syncRoleClaim` | me, once the two above are done |

Claims start working after the first item alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_