### PR TITLE
Leave the login page as soon as sign-in succeeds

### DIFF
--- a/src/components/pages/Auth/Login.jsx
+++ b/src/components/pages/Auth/Login.jsx
@@ -11,6 +11,9 @@ import './Auth.css';
 export const Login = () => {
   const { onGoogleSignIn, onEmailPasswordSignIn, onRedirectResult } = useUnifiedAuth();
   const [error, setError] = useState(null); // Use state to manage the raw error
+  // True from the moment a sign-in starts until it fails or we navigate away,
+  // so the form isn't left sitting there looking untouched mid-sign-in.
+  const [signingIn, setSigningIn] = useState(false);
 
   // When the popup is blocked (phones, strict browsers) sign-in falls back to
   // a full-page redirect; this completes that round-trip after landing back.
@@ -27,11 +30,15 @@ export const Login = () => {
   const { loading } = useAuthStore();
 
   const handleSignIn = async signInMethod => {
+    setSigningIn(true);
     const result = await signInMethod();
     if (result && !result.success) {
       setError(result.error); // Set the raw error for processing
+      setSigningIn(false); // Back to the form so they can try again
     } else {
       setError(null); // Clear error on successful authentication or if result is unexpectedly null/undefined
+      // Deliberately stays true on success: navigation is under way, and
+      // flipping back would flash the form for a frame.
     }
   };
 
@@ -42,7 +49,7 @@ export const Login = () => {
 
   return (
     <>
-      {loading ? (
+      {loading || signingIn ? (
         <LoadingSpinner />
       ) : (
         <div className="auth-page user-select-none">

--- a/src/hooks/useUnifiedAuth.js
+++ b/src/hooks/useUnifiedAuth.js
@@ -51,20 +51,27 @@ const useUnifiedAuth = () => {
   //   );
 
   const finishAuth = async (usersData, first_name, last_name) => {
-    const userData = await postUserData(usersData.user, first_name, last_name);
-    // Guard against a missing/partial payload (e.g. backend unreachable) so a
-    // successful OAuth sign-in is never reported as an auth error.
-    const emptyFields = userData?.empty_fields ?? [];
-    const roles = userData?.roles ?? [];
+    // Leave the login page the moment sign-in succeeds. This used to await
+    // postUserData first — a Firestore round trip — which left the form on
+    // screen for a second or two after the user had already signed in, looking
+    // like nothing had happened. Nothing downstream needs that write to have
+    // landed: ensureUserProfile creates the profile if it's missing.
+    navigate(await postLoginPath(), { replace: true });
 
-    if (emptyFields.length > 0) {
+    try {
+      const userData = await postUserData(usersData.user, first_name, last_name);
+      // Guard against a missing/partial payload (e.g. backend unreachable) so a
+      // successful OAuth sign-in is never reported as an auth error.
+      const emptyFields = userData?.empty_fields ?? [];
       localStorage.setItem('empty_fields', emptyFields);
-      // Keep preLoginPath: Profile consumes it once the missing fields are in.
-      navigate('/profile');
-    } else {
-      localStorage.setItem('empty_fields', emptyFields);
-      localStorage.setItem('roles', roles);
-      navigate(await postLoginPath());
+      localStorage.setItem('roles', userData?.roles ?? []);
+
+      // Only the Django provider reports missing fields; when it does, the
+      // profile form takes over from wherever we just landed.
+      if (emptyFields.length > 0) navigate('/profile', { replace: true });
+    } catch (error) {
+      // A failed profile write must not undo a successful sign-in.
+      console.error('finishAuth: profile write failed (continuing):', error);
     }
     return null; // Indicates success
   };


### PR DESCRIPTION
## Problem

After a successful sign-in the login form stayed on screen for a second or two before the dashboard appeared — looking like the click hadn't registered.

`finishAuth` **awaited `postUserData`** — a Firestore round trip — before navigating. That write is the entire delay.

## Changes

**Navigate first.** Nothing downstream needs the profile write to have landed: `ensureUserProfile` creates the profile if it's missing. The write now runs in the background, and a failure is logged rather than allowed to undo a sign-in that already worked. The Django-only `empty_fields` path still redirects to `/profile` once the response confirms fields are missing.

**Spinner during the popup round trip.** That part is a genuine wait, so the Login page shows its spinner from the moment a sign-in starts instead of leaving the form looking untouched. It deliberately stays on success — navigation is under way, and clearing it would flash the form for a frame.

## Testing

- `react-app-rewired build` — compiles, build folder ready.
- `eslint` — clean on both touched files.
- The remaining perceived delay is the Google popup itself plus route render, neither of which this touches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5FAVoSWufbux9VJRpQp5L)_